### PR TITLE
Increase .travis.yml consistency between repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: csharp
 sudo: required
 dist: trusty
-os:
-  - linux
-  - osx
 addons:
   apt:
     packages:
@@ -14,9 +11,14 @@ addons:
     - libunwind8
     - zlib1g
 env:
-  - KOREBUILD_DNU_RESTORE_CORECLR=true KOREBUILD_TEST_DNXCORE=true
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
 mono:
   - 4.0.5
+os:
+  - linux
+  - osx
 osx_image: xcode7.1
 branches:
   only:
@@ -28,4 +30,3 @@ before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 script:
   - ./build.sh --quiet verify
-  


### PR DESCRIPTION
- aspnet/Universe#349
- minimize `dotnet` setup time; no need for caching
- `KOREBUILD_DNU_RESTORE_CORECLR` and `KOREBUILD_TEST_DNXCORE` env variables aren't used anymore
