### PR TITLE
Fallback to appdomain name if entrypoint is null

### DIFF
--- a/PlatformAbstractions.sln
+++ b/PlatformAbstractions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26118.1
+VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0943D1DB-D2DA-4265-AAFD-5187B88C76D7}"
 EndProject
@@ -11,6 +11,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.PlatformAbstractions", "src\Microsoft.Extensions.PlatformAbstractions\Microsoft.Extensions.PlatformAbstractions.csproj", "{7BD814F6-722F-416E-9A38-24E69A5B2F09}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{F125A0A8-8126-4CC3-B9BD-DB1D9E1C942A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.PlatformAbstractions.Tests", "test\Microsoft.Extensions.PlatformAbstractions.Tests\Microsoft.Extensions.PlatformAbstractions.Tests.csproj", "{0CA77FA2-A071-41C7-843A-7EFF312C86DD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,11 +26,16 @@ Global
 		{7BD814F6-722F-416E-9A38-24E69A5B2F09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BD814F6-722F-416E-9A38-24E69A5B2F09}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BD814F6-722F-416E-9A38-24E69A5B2F09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CA77FA2-A071-41C7-843A-7EFF312C86DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CA77FA2-A071-41C7-843A-7EFF312C86DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CA77FA2-A071-41C7-843A-7EFF312C86DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CA77FA2-A071-41C7-843A-7EFF312C86DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7BD814F6-722F-416E-9A38-24E69A5B2F09} = {0943D1DB-D2DA-4265-AAFD-5187B88C76D7}
+		{0CA77FA2-A071-41C7-843A-7EFF312C86DD} = {F125A0A8-8126-4CC3-B9BD-DB1D9E1C942A}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Extensions.PlatformAbstractions/ApplicationEnvironment.cs
+++ b/src/Microsoft.Extensions.PlatformAbstractions/ApplicationEnvironment.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.PlatformAbstractions
     {
         public string ApplicationBasePath { get; } = GetApplicationBasePath();
 
-        public string ApplicationName { get; } = GetEntryAssembly()?.GetName().Name;
+        public string ApplicationName { get; } = GetEntryAssembly()?.GetName().Name ?? GetApplicationDomainName();
 
         public string ApplicationVersion { get; } = GetEntryAssembly()?.GetName().Version.ToString();
 
@@ -56,6 +56,15 @@ namespace Microsoft.Extensions.PlatformAbstractions
                 typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.NonPublic) ??
                 typeof(Assembly).GetMethod("GetEntryAssembly", BindingFlags.Static | BindingFlags.Public);
             return getEntryAssemblyMethod.Invoke(obj: null, parameters: Array.Empty<object>()) as Assembly;
+#endif
+        }
+
+        private static string GetApplicationDomainName()
+        {
+#if NET451
+            return AppDomain.CurrentDomain.SetupInformation.ApplicationName;
+#else
+            return null;
 #endif
         }
     }

--- a/test/Microsoft.Extensions.PlatformAbstractions.Tests/Microsoft.Extensions.PlatformAbstractions.Tests.csproj
+++ b/test/Microsoft.Extensions.PlatformAbstractions.Tests/Microsoft.Extensions.PlatformAbstractions.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\build\common.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.PlatformAbstractions\Microsoft.Extensions.PlatformAbstractions.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
+    <PackageReference Include="xunit" Version="2.2.0-*" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/test/Microsoft.Extensions.PlatformAbstractions.Tests/PlatformServicesTests.cs
+++ b/test/Microsoft.Extensions.PlatformAbstractions.Tests/PlatformServicesTests.cs
@@ -1,0 +1,14 @@
+using System;
+using Xunit;
+
+namespace Microsoft.Extensions.PlatformAbstractions.Tests
+{
+    public class PlatformServicesTests
+    {
+        [Fact]
+        public void ApplictionNameIsNotNullInAppDomain()
+        {
+            Assert.NotNull(PlatformServices.Default.Application.ApplicationName);
+        }
+    }
+}


### PR DESCRIPTION
- Added test project and test to check name on .NET Framework
and .NET Core
- Turns out the test runner sets the appdomain name to be a guid

#55 